### PR TITLE
Add CSS SVG properties to properties.txt

### DIFF
--- a/data/properties.txt
+++ b/data/properties.txt
@@ -156,6 +156,8 @@ counter-increment
 counter-reset
 crop
 cursor
+cx
+cy
 direction
 display
 dominant-baseline
@@ -398,6 +400,7 @@ position
 print-color-adjust
 punctuation-trim
 quotes
+r
 region-break-after
 region-break-before
 region-break-inside
@@ -415,6 +418,8 @@ ruby-align
 ruby-overhang
 ruby-position
 ruby-span
+rx
+ry
 scroll-behavior
 scrollbar-width
 shape-image-threshold
@@ -528,5 +533,7 @@ word-wrap
 wrap-flow
 wrap-through
 writing-mode
+x
+y
 z-index
 zoom


### PR DESCRIPTION
MDN does not have individual pages for the _CSS_ properties, but they have comments on the SVG property pages (e.g. [ry](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ry)):

> **Note:** Starting with SVG2, `ry` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for ellipses.

Here's a google search with all of the pages I could find: [site:developer.mozilla.org "meaning this attribute can also be used as a CSS property"](https://www.google.com/search?ei=sYLIXNqPPJfP0PEPmrOLiAg&q=site%3Adeveloper.mozilla.org+%22meaning+this+attribute+can+also+be+used+as+a+CSS+property%22)