### PR TITLE
Add overflow-wrap

### DIFF
--- a/data/property-sort-orders/smacss.txt
+++ b/data/property-sort-orders/smacss.txt
@@ -222,6 +222,7 @@ text-shadow
 text-transform
 text-wrap
 word-wrap
+overflow-wrap
 word-break
 
 text-emphasis


### PR DESCRIPTION
`overflow-wrap` is the standard version of `word-wrap` and so should appear just after it.