### PR TITLE
Add in scroll-margin properties to default whitelist

### DIFF
--- a/data/properties.txt
+++ b/data/properties.txt
@@ -422,6 +422,11 @@ rx
 ry
 scroll-behavior
 scrollbar-width
+scroll-margin
+scroll-margin-bottom
+scroll-margin-left
+scroll-margin-right
+scroll-margin-top
 shape-image-threshold
 shape-inside
 shape-margin

--- a/data/properties.txt
+++ b/data/properties.txt
@@ -421,12 +421,12 @@ ruby-span
 rx
 ry
 scroll-behavior
-scrollbar-width
 scroll-margin
 scroll-margin-bottom
 scroll-margin-left
 scroll-margin-right
 scroll-margin-top
+scrollbar-width
 shape-image-threshold
 shape-inside
 shape-margin


### PR DESCRIPTION
Adds in [scroll-margin](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin) to the default whitelist, see #987 .