### PR TITLE
Adds `gap` to properties.txt

### DIFF
--- a/data/properties.txt
+++ b/data/properties.txt
@@ -203,6 +203,7 @@ font-variant
 font-variant-ligatures
 font-variant-numeric
 font-weight
+gap
 glyph-orientation-horizontal
 glyph-orientation-vertical
 grid


### PR DESCRIPTION
Gap is shorthand for `row-gap` and `column-gap`.
https://developer.mozilla.org/en-US/docs/Web/CSS/gap