### PR TITLE
Add text-underline-offset as a valid property

### DIFF
--- a/data/properties.txt
+++ b/data/properties.txt
@@ -495,6 +495,7 @@ text-stroke-width
 text-transform
 text-underline-color
 text-underline-mode
+text-underline-offset
 text-underline-position
 text-underline-style
 text-underline-width


### PR DESCRIPTION
Recently started experimenting with this.

MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/text-underline-offset
Caniuse: https://caniuse.com/mdn-css_properties_text-underline-offset