### PR TITLE
Add `place-items` to properties.txt

### DIFF
--- a/data/properties.txt
+++ b/data/properties.txt
@@ -396,6 +396,7 @@ perspective-origin-x
 perspective-origin-y
 phonemes
 place-content
+place-items
 pointer-events
 position
 print-color-adjust


### PR DESCRIPTION
`place-items` is a shorthand property for `align-items` and `justify-items`.
https://developer.mozilla.org/en-US/docs/Web/CSS/place-items