### PR TITLE
Add `accent-color` to properties.txt

### DIFF
--- a/data/properties.txt
+++ b/data/properties.txt
@@ -1,4 +1,5 @@
 @keyframes
+accent-color
 align-content
 align-items
 align-self


### PR DESCRIPTION
Accent color can be used to style browser built-ins like checkboxes,
range elements and progress bars without harming accessibility.

https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color