### PR TITLE
Add in scroll-padding properties to default whitelist

### DIFF
--- a/data/properties.txt
+++ b/data/properties.txt
@@ -429,6 +429,11 @@ scroll-margin-bottom
 scroll-margin-left
 scroll-margin-right
 scroll-margin-top
+scroll-padding
+scroll-padding-bottom
+scroll-padding-left
+scroll-padding-right
+scroll-padding-top
 scrollbar-width
 shape-image-threshold
 shape-inside


### PR DESCRIPTION
The [scroll-padding property](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding) has wide support and is in a stable Candidate Recommendation stage: it would be great to add it to the default whitelist.
https://caniuse.com/?search=scroll-padding

it same like as PR #988 for `scroll-margin`.

please review this PR 🙏